### PR TITLE
Minor capitalization corrections in lang files

### DIFF
--- a/Java_Resources/assets/minecraft/lang/en_ca.json
+++ b/Java_Resources/assets/minecraft/lang/en_ca.json
@@ -2,10 +2,10 @@
   "menu.game": "ꡥꡦ",
   "menu.disconnect": "찂§cLeaving is for losers!§r찁ꢘ",
   "menu.returnToMenu": "찂§cLeaving is for losers!§r찁ꢘ",
-  "menu.returnToGame": "Back to §6Tydiumcraft!",
-  "tcMsg.addedSkin": "Successfully Applied Tool Skin!",
-  "tcMsg.unvalidSkinTool": "Please Make Sure You're Holding a Supported Item.",
-  "tcMsg.sameSkinTool": "Item Already Has This Skin.",
-  "tcMsg.noSkin": "Selected Item Doesn't Have a Set Skin.",
-  "tcMsg.resetSkin": "Successfully Reset Tool Skin!"
+  "menu.returnToGame": "Back to §6TydiumCraft!",
+  "tcMsg.addedSkin": "Successfully applied tool skin!",
+  "tcMsg.unvalidSkinTool": "Please make sure you're holding a supported item.",
+  "tcMsg.sameSkinTool": "Item already has this skin.",
+  "tcMsg.noSkin": "Selected item doesn't have a set skin.",
+  "tcMsg.resetSkin": "Successfully reset tool skin!"
 }

--- a/Java_Resources/assets/minecraft/lang/en_gb.json
+++ b/Java_Resources/assets/minecraft/lang/en_gb.json
@@ -2,10 +2,10 @@
   "menu.game": "ꡥꡦ",
   "menu.disconnect": "찂§cLeaving is for losers!§r찁ꢘ",
   "menu.returnToMenu": "찂§cLeaving is for losers!§r찁ꢘ",
-  "menu.returnToGame": "Back to §6Tydiumcraft!",
-  "tcMsg.addedSkin": "Successfully Applied Tool Skin!",
-  "tcMsg.unvalidSkinTool": "Please Make Sure You're Holding a Supported Item.",
-  "tcMsg.sameSkinTool": "Item Already Has This Skin.",
-  "tcMsg.noSkin": "Selected Item Doesn't Have a Set Skin.",
-  "tcMsg.resetSkin": "Successfully Reset Tool Skin!"
+  "menu.returnToGame": "Back to §6TydiumCraft!",
+  "tcMsg.addedSkin": "Successfully applied tool skin!",
+  "tcMsg.unvalidSkinTool": "Please make sure you're holding a supported item.",
+  "tcMsg.sameSkinTool": "Item already has this skin.",
+  "tcMsg.noSkin": "Selected item doesn't have a set skin.",
+  "tcMsg.resetSkin": "Successfully reset tool skin!"
 }

--- a/Java_Resources/assets/minecraft/lang/en_nz.json
+++ b/Java_Resources/assets/minecraft/lang/en_nz.json
@@ -2,10 +2,10 @@
   "menu.game": "ꡥꡦ",
   "menu.disconnect": "찂§cLeaving is for losers!§r찁ꢘ",
   "menu.returnToMenu": "찂§cLeaving is for losers!§r찁ꢘ",
-  "menu.returnToGame": "Back to §6Tydiumcraft!",
-  "tcMsg.addedSkin": "Successfully Applied Tool Skin!",
-  "tcMsg.unvalidSkinTool": "Please Make Sure You're Holding a Supported Item.",
-  "tcMsg.sameSkinTool": "Item Already Has This Skin.",
-  "tcMsg.noSkin": "Selected Item Doesn't Have a Set Skin.",
-  "tcMsg.resetSkin": "Successfully Reset Tool Skin!"
+  "menu.returnToGame": "Back to §6TydiumCraft!",
+  "tcMsg.addedSkin": "Successfully applied tool skin!",
+  "tcMsg.unvalidSkinTool": "Please make sure you're holding a supported item.",
+  "tcMsg.sameSkinTool": "Item already has this skin.",
+  "tcMsg.noSkin": "Selected item doesn't have a set skin.",
+  "tcMsg.resetSkin": "Successfully reset tool skin!"
 }

--- a/Java_Resources/assets/minecraft/lang/en_uk.json
+++ b/Java_Resources/assets/minecraft/lang/en_uk.json
@@ -2,10 +2,10 @@
   "menu.game": "ꡥꡦ",
   "menu.disconnect": "찂§cLeaving is for losers!§r찁ꢘ",
   "menu.returnToMenu": "찂§cLeaving is for losers!§r찁ꢘ",
-  "menu.returnToGame": "Back to §6Tydiumcraft!",
-  "tcMsg.addedSkin": "Successfully Applied Tool Skin!",
-  "tcMsg.unvalidSkinTool": "Please Make Sure You're Holding a Supported Item.",
-  "tcMsg.sameSkinTool": "Item Already Has This Skin.",
-  "tcMsg.noSkin": "Selected Item Doesn't Have a Set Skin.",
-  "tcMsg.resetSkin": "Successfully Reset Tool Skin!"
+  "menu.returnToGame": "Back to §6TydiumCraft!",
+  "tcMsg.addedSkin": "Successfully applied tool skin!",
+  "tcMsg.unvalidSkinTool": "Please make sure you're holding a supported item.",
+  "tcMsg.sameSkinTool": "Item already has this skin.",
+  "tcMsg.noSkin": "Selected item doesn't have a set skin.",
+  "tcMsg.resetSkin": "Successfully reset tool skin!"
 }

--- a/Java_Resources/assets/minecraft/lang/en_us.json
+++ b/Java_Resources/assets/minecraft/lang/en_us.json
@@ -2,10 +2,10 @@
   "menu.game": "ꡥꡦ",
   "menu.disconnect": "찂§cLeaving is for losers!§r찁ꢘ",
   "menu.returnToMenu": "찂§cLeaving is for losers!§r찁ꢘ",
-  "menu.returnToGame": "Back to §6Tydiumcraft!",
-  "tcMsg.addedSkin": "Successfully Applied Tool Skin!",
-  "tcMsg.unvalidSkinTool": "Please Make Sure You're Holding a Supported Item.",
-  "tcMsg.sameSkinTool": "Item Already Has This Skin.",
-  "tcMsg.noSkin": "Selected Item Doesn't Have a Set Skin.",
-  "tcMsg.resetSkin": "Successfully Reset Tool Skin!"
+  "menu.returnToGame": "Back to §6TydiumCraft!",
+  "tcMsg.addedSkin": "Successfully applied tool skin!",
+  "tcMsg.unvalidSkinTool": "Please make sure you're holding a supported item.",
+  "tcMsg.sameSkinTool": "Item already has this skin.",
+  "tcMsg.noSkin": "Selected item doesn't have a set skin.",
+  "tcMsg.resetSkin": "Successfully reset tool skin!"
 }

--- a/Tydiumcraft-Halloween-Java/assets/minecraft/lang/en_us.json
+++ b/Tydiumcraft-Halloween-Java/assets/minecraft/lang/en_us.json
@@ -1,3 +1,3 @@
 {
-  "menu.returnToGame": "Back to §2Tydiumcraft!"
+  "menu.returnToGame": "Back to §2TydiumCraft!"
 }


### PR DESCRIPTION
- Change "Tydiumcraft" to "TydiumCraft" to match the rest of the server's branding
- Remove excessive capitalization of random words throughout a sentence

A few other suggestions beyond the scope of this PR:
- Change the "Leaving is for losers!" disconnect button label 
- Move `tcMsg.*` lang definitions into the `tydiumcraft:` namespace 